### PR TITLE
fix dimension stack crash

### DIFF
--- a/src/main/java/qouteall/imm_ptl/core/platform_specific/O_O.java
+++ b/src/main/java/qouteall/imm_ptl/core/platform_specific/O_O.java
@@ -242,9 +242,11 @@ public class O_O {
     
     @Nullable
     public static String getModName(String modid) {
-        return FMLLoader.getLoadingModList().getModFileById(modid).getMods().stream().findFirst().get().getDisplayName();
+        if (ModList.get().getModFileById(modid) == null) {
+            return modid;
+        }
+        return ModList.get().getModFileById(modid).getMods().stream().findFirst().get().getDisplayName();
     }
-    
     // most quilt installations use quilted fabric api
     public static boolean isQuilt() {
         return false;


### PR DESCRIPTION
Resolves #8 
instead of crashing when no display name for the mod can be found, uses the modid in its place